### PR TITLE
Fix homebrew warning

### DIFF
--- a/cmus-control.rb
+++ b/cmus-control.rb
@@ -6,7 +6,7 @@ class CmusControl < Formula
   sha256 "d99f061990cd83972dd1a793829cbde9cc3f1548a666d599a206cd8ba4dece0f"
 
   depends_on "cmake" => :build
-  depends_on "cmus" => :run
+  depends_on "cmus"
 
   def install
     system "make", "build/release"


### PR DESCRIPTION
```
Warning: Calling 'depends_on ... => :run' is deprecated!
There is no replacement.
/usr/local/Homebrew/Library/Taps/thefox/homebrew-brewery/cmus-control.rb:9:in `<class:CmusControl>'
Please report this to the thefox/brewery tap!```