### PR TITLE
Fixes problem installing plist

### DIFF
--- a/cmus-control.rb
+++ b/cmus-control.rb
@@ -14,7 +14,7 @@ class CmusControl < Formula
     bin.install "build/release/bin/cmuscontrold"
   end
 
-  def caveats; <<-EOS.undent
+  def caveats; <<-EOS
     Since Cmus Control doesn't have the behavior of changing any foreign processes it's highly recommended to deactivate Apples Remote Control Daemon:
 
       launchctl unload -w /System/Library/LaunchAgents/com.apple.rcd.plist
@@ -27,7 +27,7 @@ class CmusControl < Formula
 
   plist_options :startup => true, :manual => "cmuscontrold"
 
-  def plist; <<-EOS.undent
+  def plist; <<-EOS
     <?xml version="1.0" encoding="UTF-8"?>
     <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
     <plist version="1.0">


### PR DESCRIPTION
```brew install cmus-control
==> Installing cmus-control from olorton/brewery
==> Downloading
https://github.com/TheFox/cmus-control/archive/v1.0.2.tar.gz
Already downloaded:
/Users/oliver/Library/Caches/Homebrew/cmus-control-1.0.2.tar.gz
==> make build/release
Error: Failed to install plist file
Error: Calling <<-EOS.undent is disabled!
Use <<~EOS instead.
/usr/local/Homebrew/Library/Taps/olorton/homebrew-brewery/cmus-control.rb:25:in
`caveats'
Please report this to the olorton/brewery tap!
Or, even better, submit a PR to fix it!